### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# [0.4.0](https://github.com/algolia/shipjs/compare/v0.3.4...v0.4.0) (2019-08-20)
+
+
+### Bug Fixes
+
+* fix --no-browse option ([#195](https://github.com/algolia/shipjs/issues/195)) ([f923e52](https://github.com/algolia/shipjs/commit/f923e52))
+* skip notification when args not given ([#199](https://github.com/algolia/shipjs/issues/199)) ([b0be6bf](https://github.com/algolia/shipjs/commit/b0be6bf))
+
+
+### Features
+
+* accept slack incoming hook from ENV ([#200](https://github.com/algolia/shipjs/issues/200)) ([f941bd7](https://github.com/algolia/shipjs/commit/f941bd7))
+* add notification for prepare ([#198](https://github.com/algolia/shipjs/issues/198)) ([c0388cb](https://github.com/algolia/shipjs/commit/c0388cb))
+
+
+
 ## [0.3.4](https://github.com/algolia/shipjs/compare/v0.3.3...v0.3.4) (2019-08-20)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.3.4",
+  "version": "0.4.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/shipjs-lib/package.json
+++ b/packages/shipjs-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipjs-lib",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "",
   "main": "dist/index.esm.js",
   "scripts": {

--- a/packages/shipjs/package.json
+++ b/packages/shipjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipjs",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "",
   "main": "index.js",
   "bin": {
@@ -31,7 +31,7 @@
     "conventional-changelog-cli": "2.0.23",
     "esm": "3.2.25",
     "inquirer": "6.5.1",
-    "shipjs-lib": "0.3.4",
+    "shipjs-lib": "0.4.0",
     "temp-write": "4.0.0"
   },
   "devDependencies": {

--- a/packages/shipjs/src/version.js
+++ b/packages/shipjs/src/version.js
@@ -1,1 +1,1 @@
-export default '0.3.4';
+export default '0.4.0';


### PR DESCRIPTION
## Release Summary
- Version change: `v0.3.4` → `v0.4.0`
- Merge: `releases/v0.4.0` → `master`
- [Compare the changes between the versions](https://github.com/algolia/shipjs/compare/v0.3.4...releases/v0.4.0)