### PR TITLE
feat: create GitHub releases

### DIFF
--- a/packages/shipjs/src/flow/release.js
+++ b/packages/shipjs/src/flow/release.js
@@ -13,6 +13,7 @@ import runPublish from '../step/release/runPublish';
 import runAfterPublish from '../step/release/runAfterPublish';
 import createGitTag from '../step/release/createGitTag';
 import gitPush from '../step/release/gitPush';
+import createGitHubRelease from '../step/release/createGitHubRelease';
 import notifyReleaseSuccess from '../step/release/notifyReleaseSuccess';
 import finished from '../step/finished';
 
@@ -49,6 +50,9 @@ async function release({ help = false, dir = '.', dryRun = false }) {
   await runAfterPublish({ config, dir, dryRun });
   const { tagName } = createGitTag({ version, config, dir, dryRun });
   gitPush({ tagName, config, dir, dryRun });
+
+  createGitHubRelease({ version, config, dir, dryRun });
+
   await notifyReleaseSuccess({
     config,
     appName,

--- a/packages/shipjs/src/flow/release.js
+++ b/packages/shipjs/src/flow/release.js
@@ -50,9 +50,7 @@ async function release({ help = false, dir = '.', dryRun = false }) {
   await runAfterPublish({ config, dir, dryRun });
   const { tagName } = createGitTag({ version, config, dir, dryRun });
   gitPush({ tagName, config, dir, dryRun });
-
   createGitHubRelease({ version, config, dir, dryRun });
-
   await notifyReleaseSuccess({
     config,
     appName,

--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -2,7 +2,7 @@ import runStep from '../runStep';
 import path from 'path';
 
 export default ({ version, config, dir, dryRun }) =>
-  runStep({ title: 'Updating the changelog.' }, ({ run }) => {
+  runStep({ title: 'Creating the GitHub Release' }, ({ run }) => {
     if (config.updateChangelog !== true) {
       return;
     }

--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -1,7 +1,8 @@
-import runStep from '../runStep';
-import path from 'path';
 import fs from 'fs';
+import path from 'path';
 import tempWrite from 'temp-write';
+
+import runStep from '../runStep';
 
 function getChangelog(version) {
   const changelogMatcher = new RegExp(
@@ -42,7 +43,11 @@ export default ({ version, config, dir, dryRun }) =>
 
       const conventionalChangelog = path.resolve(
         require.main.filename,
-        '../../node_modules/.bin/conventional-changelog'
+        '..',
+        '..',
+        'node_modules',
+        '.bin',
+        'conventional-changelog'
       );
       const changelogCommand = [
         conventionalChangelog,

--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import path from 'path';
 import tempWrite from 'temp-write';
 
 import runStep from '../runStep';
@@ -13,7 +12,8 @@ function getChangelog(version, rootDir) {
     const changelogFile = fs.readFileSync(changelogPath, 'utf-8').toString();
     const changelogMatch = changelogFile.match(changelogMatcher);
     if (changelogMatch !== null) {
-      return changelogMatch[0];
+      // because first line of a log file must be title of the release
+      return `${version}\n\n${changelogMatch[0]}`;
     }
   } catch (err) {
     if (err.code === 'ENOENT') {
@@ -24,7 +24,7 @@ function getChangelog(version, rootDir) {
   return null;
 }
 
-export default ({ version, config, dir, dryRun, print }) =>
+export default ({ version, config, dir, dryRun }) =>
   runStep({ title: 'Creating a release on GitHub repository' }, ({ run }) => {
     if (config.updateChangelog !== true) return;
 

--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -27,13 +27,13 @@ function getChangelog(version, rootDir) {
 
 export default ({ version, config, dir, dryRun }) =>
   runStep({ title: 'Creating a release on GitHub repository' }, ({ run }) => {
-    if (config.updateChangelog !== true) return;
-
     const { getTagName } = config;
     const tagName = getTagName({ version });
 
     // extract matching changelog
-    const changelog = getChangelog(version, dir);
+    const changelog = config.updateChangelog
+      ? getChangelog(version, dir)
+      : null;
     const exportedPath = tempWrite.sync(changelog || tagName);
 
     // create GitHub release

--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -45,5 +45,5 @@ export default ({ version, config, dir, dryRun }) =>
       tagName,
     ].join(' ');
 
-    run(releaseCommand, dir, dryRun);
+    run({ command: releaseCommand, dir, dryRun });
   });

--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -1,0 +1,27 @@
+import runStep from '../runStep';
+import path from 'path';
+
+export default ({ version, config, dir, dryRun }) =>
+  runStep({ title: 'Updating the changelog.' }, ({ run }) => {
+    if (config.updateChangelog !== true) {
+      return;
+    }
+    const { getTagName } = config;
+    const tagName = getTagName({ version });
+
+    const args = ['-p angular', '-r 2'].join(' ');
+    const execPath = path.resolve(
+      require.main.filename,
+      '../../node_modules/.bin/conventional-changelog'
+    );
+    const changelog = run(`${execPath} ${args}`, dir, dryRun);
+    const releaseString = `${tagName}
+
+${dryRun ? '#changelog has been omitted because of dryRun#' : changelog}`;
+
+    const releaseCommand = `cat <<EOD | hub release create -F - ${tagName}
+${releaseString}
+EOD`;
+
+    run(releaseCommand, dir, dryRun);
+  });

--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import tempWrite from 'temp-write';
 
 import runStep from '../runStep';
@@ -7,7 +8,7 @@ function getChangelog(version, rootDir) {
   const changelogMatcher = new RegExp(
     `#+?[\\s\\[]*?(${version})(.|\n)+?(?=#+?[\\s\\[]*?\\d\\.\\d|$)`
   );
-  const changelogPath = fs.resolve(rootDir, 'CHANGELOG.md');
+  const changelogPath = path.resolve(rootDir, 'CHANGELOG.md');
   try {
     const changelogFile = fs.readFileSync(changelogPath, 'utf-8').toString();
     const changelogMatch = changelogFile.match(changelogMatcher);

--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -1,27 +1,66 @@
 import runStep from '../runStep';
 import path from 'path';
+import fs from 'fs';
+import tempWrite from 'temp-write';
+
+function getChangelog(version) {
+  const changelogMatcher = new RegExp(
+    `#+?[\\s\\[]*?(${version})(.|\n)+?(?=#+?[\\s\\[]*?\\d\\.\\d|$)`
+  );
+  const changelogPath = fs.resolve(process.cwd(), 'CHANGELOG.md');
+  try {
+    const changelogFile = fs.readFileSync(changelogPath, 'utf-8').toString();
+    const changelogMatch = changelogFile.match(changelogMatcher);
+    if (changelogMatch !== null) {
+      return changelogMatch[0];
+    }
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+  return null;
+}
 
 export default ({ version, config, dir, dryRun }) =>
   runStep({ title: 'Creating the GitHub Release' }, ({ run }) => {
-    if (config.updateChangelog !== true) {
-      return;
-    }
+    if (config.updateChangelog !== true) return;
+
     const { getTagName } = config;
     const tagName = getTagName({ version });
 
-    const args = ['-p angular', '-r 2'].join(' ');
-    const execPath = path.resolve(
-      require.main.filename,
-      '../../node_modules/.bin/conventional-changelog'
-    );
-    const changelog = run(`${execPath} ${args}`, dir, dryRun);
-    const releaseString = `${tagName}
+    const existingChangelog = getChangelog(version);
+    let exportedPath;
+    if (existingChangelog !== null) {
+      // fetch CHANGELOG
+      exportedPath = tempWrite.sync(existingChangelog);
+    } else {
+      // generate CHANGELOG
+      const tmpDir = fs.mkdtempSync('shipjs');
+      exportedPath = path.join(tmpDir, 'changelog');
 
-${dryRun ? '#changelog has been omitted because of dryRun#' : changelog}`;
+      const conventionalChangelog = path.resolve(
+        require.main.filename,
+        '../../node_modules/.bin/conventional-changelog'
+      );
+      const changelogCommand = [
+        conventionalChangelog,
+        '-p angular',
+        '-r 2',
+        `-o ${exportedPath}`,
+      ].join(' ');
 
-    const releaseCommand = `cat <<EOD | hub release create -F - ${tagName}
-${releaseString}
-EOD`;
+      run(changelogCommand, dir, dryRun);
+    }
 
+    // Create GitHub release
+    const releaseCommand = [
+      'hub',
+      'release',
+      'create',
+      `-F ${exportedPath}`,
+      tagName,
+    ].join(' ');
     run(releaseCommand, dir, dryRun);
   });

--- a/packages/shipjs/src/util/wrapRun.js
+++ b/packages/shipjs/src/util/wrapRun.js
@@ -13,14 +13,12 @@ export default ({ exec, print, error }) => ({
   if (dryRun) {
     return;
   }
-  const { code } = exec(command, { dir });
-  if (code !== 0) {
-    if (printCommand) {
-      print(error('The following command failed:'));
-      print(`  > ${command}`);
-    } else {
-      print(error('Command failed'));
-    }
+  const result = exec(command, { dir });
+  if (result.code !== 0) {
+    print(error('The following command failed:'));
+    print(`  > ${command}`);
     process.exit(1); // eslint-disable-line no-process-exit
   }
+  // eslint-disable-next-line consistent-return
+  return result.stdout;
 };

--- a/packages/shipjs/src/util/wrapRun.js
+++ b/packages/shipjs/src/util/wrapRun.js
@@ -13,12 +13,10 @@ export default ({ exec, print, error }) => ({
   if (dryRun) {
     return;
   }
-  const result = exec(command, { dir });
-  if (result.code !== 0) {
+  const { code } = exec(command, { dir });
+  if (code !== 0) {
     print(error('The following command failed:'));
     print(`  > ${command}`);
     process.exit(1); // eslint-disable-line no-process-exit
   }
-  // eslint-disable-next-line consistent-return
-  return result.stdout;
 };

--- a/packages/shipjs/src/util/wrapRun.js
+++ b/packages/shipjs/src/util/wrapRun.js
@@ -15,8 +15,12 @@ export default ({ exec, print, error }) => ({
   }
   const { code } = exec(command, { dir });
   if (code !== 0) {
-    print(error('The following command failed:'));
-    print(`  > ${command}`);
+    if (printCommand) {
+      print(error('The following command failed:'));
+      print(`  > ${command}`);
+    } else {
+      print(error('Command failed'));
+    }
     process.exit(1); // eslint-disable-line no-process-exit
   }
 };


### PR DESCRIPTION
This PR injects `createGitHubRelease` into `release`.

#### What `createGitHubRelease` do

- Get changelog from `conventional-changelog`
- `hub release create` with changelog

Possibly fixes #109

> Edit PR freely