### PR TITLE
fix: detecting yarn in setup script

### DIFF
--- a/packages/shipjs/src/step/setup/addDevDependencies.js
+++ b/packages/shipjs/src/step/setup/addDevDependencies.js
@@ -6,7 +6,7 @@ import path from 'path';
 
 export default ({ dependencies, dir }) =>
   runStep({ title: 'Installing Ship.js' }, () => {
-    const command = detectYarn
+    const command = detectYarn(dir)
       ? `yarn add -D ${dependencies.join(' ')}${
           usesYarnWorkspace(dir) ? ' -W' : ''
         }`


### PR DESCRIPTION
`detectYarn` is function, but used as `Boolean`

Fixed that