### PR TITLE
fix(getChangelog): wrong argument name

### DIFF
--- a/packages/shipjs/src/helper/getChangelog.js
+++ b/packages/shipjs/src/helper/getChangelog.js
@@ -2,8 +2,8 @@ import path from 'path';
 import fs from 'fs';
 import { extractSpecificChangelog } from './';
 
-export default function getChangelog({ version, rootDir }) {
-  const changelogPath = path.resolve(rootDir, 'CHANGELOG.md');
+export default function getChangelog({ version, dir }) {
+  const changelogPath = path.resolve(dir, 'CHANGELOG.md');
   try {
     const changelogFile = fs.readFileSync(changelogPath, 'utf-8').toString();
     return extractSpecificChangelog({ changelogFile, version });


### PR DESCRIPTION
`npm run release:trigger` ends with this error:

```
› Creating a release on GitHub repository
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
    at validateString (internal/validators.js:112:11)
    at Proxy.resolve (path.js:981:7)
    at getChangelog (/Users/jeetiss/Projects/try-shipjs/node_modules/shipjs/src/helper/getChangelog.js:7:46)
```
fix that