### PR TITLE
feat: add support for scoped packages

### DIFF
--- a/packages/shipjs/package.json
+++ b/packages/shipjs/package.json
@@ -45,6 +45,7 @@
     "inquirer": "7.0.0",
     "mkdirp": "^0.5.1",
     "prettier": "^1.18.2",
+    "serialize-javascript": "^2.1.0",
     "shell-quote": "^1.7.2",
     "shipjs-lib": "0.10.0",
     "temp-write": "4.0.0"

--- a/packages/shipjs/package.json
+++ b/packages/shipjs/package.json
@@ -44,6 +44,7 @@
     "globby": "^10.0.1",
     "inquirer": "7.0.0",
     "mkdirp": "^0.5.1",
+    "npm-package-arg": "^7.0.0",
     "prettier": "^1.18.2",
     "shell-quote": "^1.7.2",
     "shipjs-lib": "0.10.0",

--- a/packages/shipjs/package.json
+++ b/packages/shipjs/package.json
@@ -44,7 +44,6 @@
     "globby": "^10.0.1",
     "inquirer": "7.0.0",
     "mkdirp": "^0.5.1",
-    "npm-package-arg": "^7.0.0",
     "prettier": "^1.18.2",
     "shell-quote": "^1.7.2",
     "shipjs-lib": "0.10.0",

--- a/packages/shipjs/src/flow/setup.js
+++ b/packages/shipjs/src/flow/setup.js
@@ -22,11 +22,15 @@ async function setup({ help = false, dir = '.' }) {
     mainVersionFile,
     packagesToBump,
     packagesToPublish,
+    isScoped,
+    isPublic,
   } = await askQuestions({ dir });
   const outputs = [
     addDevDependencies({ dependencies: ['shipjs'], dir }),
     addScriptsToPackageJson({ dir }),
     await addShipConfig({
+      isScoped,
+      isPublic,
       baseBranch,
       releaseBranch,
       useMonorepo,

--- a/packages/shipjs/src/step/setup/addShipConfig.js
+++ b/packages/shipjs/src/step/setup/addShipConfig.js
@@ -6,6 +6,8 @@ import { info } from '../../color';
 import { print } from '../../util';
 
 export default async ({
+  isScoped,
+  isPublic,
   baseBranch,
   releaseBranch,
   useMonorepo,
@@ -17,6 +19,9 @@ export default async ({
   await runStep({ title: 'Creating ship.config.js' }, async () => {
     const filePath = path.resolve(dir, 'ship.config.js');
     const json = {
+      publishCommand: !xor(isPublic, isScoped)
+        ? createPublishCommand(isPublic)
+        : undefined,
       mergeStrategy:
         baseBranch === releaseBranch
           ? {
@@ -47,3 +52,15 @@ export default async ({
       print('  > https://github.com/algolia/shipjs/blob/master/GUIDE.md');
     };
   });
+
+function createPublishCommand(isPublic) {
+  const command = isPublic
+    ? ({ defaultCommand }) => `${defaultCommand} --access public`
+    : ({ defaultCommand }) => `${defaultCommand} --access restricted`;
+
+  return command.toString();
+}
+
+function xor(a, b) {
+  return (a && !b) || (!a && b);
+}

--- a/packages/shipjs/src/step/setup/addShipConfig.js
+++ b/packages/shipjs/src/step/setup/addShipConfig.js
@@ -19,9 +19,7 @@ export default async ({
   await runStep({ title: 'Creating ship.config.js' }, async () => {
     const filePath = path.resolve(dir, 'ship.config.js');
     const json = {
-      publishCommand: !xor(isPublic, isScoped)
-        ? createPublishCommand(isPublic)
-        : undefined,
+      publishCommand: isScoped && isPublic ? createPublishCommand() : undefined,
       mergeStrategy:
         baseBranch === releaseBranch
           ? {
@@ -53,14 +51,7 @@ export default async ({
     };
   });
 
-function createPublishCommand(isPublic) {
-  const command = isPublic
-    ? ({ defaultCommand }) => `${defaultCommand} --access public`
-    : ({ defaultCommand }) => `${defaultCommand} --access restricted`;
-
-  return command.toString();
-}
-
-function xor(a, b) {
-  return (a && !b) || (!a && b);
+function createPublishCommand() {
+  return (({ defaultCommand }) =>
+    `${defaultCommand} --access public`).toString();
 }

--- a/packages/shipjs/src/step/setup/askQuestions.js
+++ b/packages/shipjs/src/step/setup/askQuestions.js
@@ -2,7 +2,6 @@ import inquirer from 'inquirer';
 import { getRemoteBranches } from 'shipjs-lib';
 import fs from 'fs';
 import path from 'path';
-import npa from 'npm-package-arg';
 import runStep from '../runStep';
 import { grey, reset } from '../../color';
 
@@ -281,7 +280,7 @@ function stringArrayValidator(answer) {
 
 function isScopedPackage(name) {
   try {
-    return npa(name).scope !== null;
+    return name[0] === '@' && name.indexOf('/') !== -1;
   } catch (err) {
     return false;
   }

--- a/packages/shipjs/src/step/setup/askQuestions.js
+++ b/packages/shipjs/src/step/setup/askQuestions.js
@@ -202,6 +202,10 @@ async function askMonorepo(dir) {
 async function askPackageAccess(dir) {
   const isScoped = isScopedPackage(getJson(dir, 'package.json').name);
 
+  if (!isScoped) {
+    return { isScoped };
+  }
+
   const { isPublic } = await inquirer.prompt([
     {
       type: 'confirm',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4391,6 +4391,13 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
+hosted-git-info@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.2.tgz#8b7e3bd114b59b51786f8bade0f39ddc80275a97"
+  integrity sha512-ezZMWtHXm7Eb7Rq4Mwnx2vs79WUx2QmRg3+ZqeGroKzfDO+EprOcgRPYghsOP9JuYBfK18VojmRTGCg8Ma+ktw==
+  dependencies:
+    lru-cache "^5.1.1"
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -6288,6 +6295,16 @@ npm-lifecycle@^3.1.2:
     hosted-git-info "^2.6.0"
     osenv "^0.1.5"
     semver "^5.5.0"
+    validate-npm-package-name "^3.0.0"
+
+npm-package-arg@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-7.0.0.tgz#52cdf08b491c0c59df687c4c925a89102ef794a5"
+  integrity sha512-xXxr8y5U0kl8dVkz2oK7yZjPBvqM2fwaO5l3Yg13p03v8+E3qQcD0JNhHzjL1vyGgxcKkD0cco+NLR72iuPk3g==
+  dependencies:
+    hosted-git-info "^3.0.2"
+    osenv "^0.1.5"
+    semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
 npm-packlist@^1.1.6, npm-packlist@^1.4.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4391,13 +4391,6 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
-hosted-git-info@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.2.tgz#8b7e3bd114b59b51786f8bade0f39ddc80275a97"
-  integrity sha512-ezZMWtHXm7Eb7Rq4Mwnx2vs79WUx2QmRg3+ZqeGroKzfDO+EprOcgRPYghsOP9JuYBfK18VojmRTGCg8Ma+ktw==
-  dependencies:
-    lru-cache "^5.1.1"
-
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -6295,16 +6288,6 @@ npm-lifecycle@^3.1.2:
     hosted-git-info "^2.6.0"
     osenv "^0.1.5"
     semver "^5.5.0"
-    validate-npm-package-name "^3.0.0"
-
-npm-package-arg@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-7.0.0.tgz#52cdf08b491c0c59df687c4c925a89102ef794a5"
-  integrity sha512-xXxr8y5U0kl8dVkz2oK7yZjPBvqM2fwaO5l3Yg13p03v8+E3qQcD0JNhHzjL1vyGgxcKkD0cco+NLR72iuPk3g==
-  dependencies:
-    hosted-git-info "^3.0.2"
-    osenv "^0.1.5"
-    semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
 npm-packlist@^1.1.6, npm-packlist@^1.4.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7465,6 +7465,11 @@ sentence-case@^2.1.0:
     no-case "^2.2.0"
     upper-case-first "^1.1.2"
 
+serialize-javascript@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.0.tgz#9310276819efd0eb128258bb341957f6eb2fc570"
+  integrity sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
re #436 
- added question about package access on setup step
- added `isScopedPackage` verification on setup step
- added custom `publishCommand` to config, based on information from previous step

PS: I added restricted access except scoped package support, if somebody with default package (not scoped) chose don't publish public package. Setup script will add custom `publishCommand` with `--access restricted` 🤖