### PR TITLE
fix: replace GH_TOKEN with GITHUB_TOKEN

### DIFF
--- a/packages/shipjs/src/step/setup/CI/addGitHubActions.js
+++ b/packages/shipjs/src/step/setup/CI/addGitHubActions.js
@@ -113,7 +113,7 @@ jobs:
           fi
       - run: npm run release:trigger
         env:
-          GITHUB_TOKEN: \${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: \${{ secrets.NPM_AUTH_TOKEN }}
           SLACK_INCOMING_HOOK: \${{ secrets.SLACK_INCOMING_HOOK }}
 `,
@@ -151,7 +151,7 @@ jobs:
           git config --global user.name "<%= gitUserName %>"
       - run: npm run release:prepare -- --yes --no-browse
         env:
-          GITHUB_TOKEN: \${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           SLACK_INCOMING_HOOK: \${{ secrets.SLACK_INCOMING_HOOK }}
 
   create_done_comment:
@@ -212,7 +212,7 @@ jobs:
           git config --global user.name "<%= gitUserName %>"
       - run: npm run release:prepare -- --yes --no-browse
         env:
-          GITHUB_TOKEN: \${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           SLACK_INCOMING_HOOK: \${{ secrets.SLACK_INCOMING_HOOK }}
 `,
     { baseBranch, cronExpr, gitUserName, gitUserEmail }

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -124,26 +124,11 @@ Setup a GitHub token to allow Ship.js(**at CircleCI**) to create a git tag and p
 
 ## Setup GitHub Actions
 
-If you are using GitHub Actions, you need to setup the following tokens:
+If you are using GitHub Actions, you need to setup the NPM token to release package to NPM:
 
-- NPM token: To release package to NPM
-- GitHub token: To create release notes and tags
-
-### NPM Token
-
-1. Login at [https://www.npmjs.com/](https://www.npmjs.com/), click your profile icon and go to "Tokens".
+1. Login at [https://www.npmjs.com/](https://www.npmjs.com/), click your profile icon and go to "Auth Tokens".
 2. Click "Create New Token", make sure the access level is "Read and Publish" and copy the token.
 3. At your GitHub repo, go to "Settings" → "Secrets".
 4. Click "Add a new secret".
    - Name: `NPM_AUTH_TOKEN`
-   - Value: Paste the token from clipboard.
-
-### GitHub Token
-
-1. Go to https://github.com/settings/tokens/new
-2. Check "repo(Full control of private repositories)"
-3. Generate/copy the token
-4. At your GitHub repo, go to "Settings" → "Secrets".
-5. Click "Add a new secret".
-   - Name: `GH_TOKEN`
    - Value: Paste the token from clipboard.


### PR DESCRIPTION
Just realize that we don't need `GH_TOKEN` for releases. I found library `changesets`  and they create releases with github bot 👉🏻https://github.com/atlassian/changesets/releases

I think that GITHUB_TOKEN don't provide enough rights for all todos and because of that `shipjs trigger` fails  https://github.com/jeetiss/try-shipjs/runs/330554677#step:6:54 , but problem was in different thing

I test GITHUB_TOKEN and every works fine now (see last release) https://github.com/jeetiss/try-shipjs/releases so I replace all tokens to GITHUB_TOKEN and change github actions guide

Sorry about that :)

