### PR TITLE
fix: clean up all cases for releaseType

### DIFF
--- a/packages/shipjs-lib/src/lib/util/__tests__/getReleaseType.spec.js
+++ b/packages/shipjs-lib/src/lib/util/__tests__/getReleaseType.spec.js
@@ -1,7 +1,29 @@
 import getReleaseType from '../getReleaseType';
 
 describe('getReleaseType', () => {
-  it('gets release type from current version and next version', () => {
-    expect(getReleaseType('1.0.0', '0.10.99')).toBe('major');
+  it('works', () => {
+    const list = [
+      ['1.2.3', '2.0.0', 'major'],
+      ['1.2.3', '1.3.0', 'minor'],
+      ['1.2.3', '1.2.4', 'patch'],
+      ['1.2.3', '1.2.4-alpha.0', 'prerelease'],
+
+      ['1.2.4-alpha.0', '1.2.4-alpha.1', 'prerelease'],
+      ['1.2.4-alpha.0', '1.2.4', 'patch'],
+      ['1.2.4-alpha.0', '1.2.5', 'patch'],
+      ['1.2.4-alpha.0', '1.3.0', 'minor'],
+      ['1.2.4-alpha.0', '2.0.0', 'major'],
+
+      ['1.3.0-alpha.0', '1.3.0', 'minor'],
+    ];
+
+    list.forEach(([currentVersion, nextVersion, expected]) => {
+      const actual = getReleaseType(currentVersion, nextVersion);
+      expect({ currentVersion, nextVersion, result: actual }).toEqual({
+        currentVersion,
+        nextVersion,
+        result: expected,
+      });
+    });
   });
 });

--- a/packages/shipjs-lib/src/lib/util/getReleaseType.js
+++ b/packages/shipjs-lib/src/lib/util/getReleaseType.js
@@ -1,5 +1,19 @@
-import { diff } from 'semver';
+import { diff, prerelease, minor, patch } from 'semver';
 
 export default function getReleaseType(currentVersion, nextVersion) {
+  if (prerelease(currentVersion) === null && prerelease(nextVersion) !== null) {
+    return 'prerelease';
+  }
+  if (prerelease(currentVersion) !== null && prerelease(nextVersion) === null) {
+    if (patch(nextVersion) === 0) {
+      if (minor(nextVersion) === 0) {
+        return 'major';
+      } else {
+        return 'minor';
+      }
+    } else {
+      return 'patch';
+    }
+  }
   return diff(currentVersion, nextVersion);
 }


### PR DESCRIPTION
closes #594.

This PR fixes `getReleaseType`.

## normal cases
- `1.2.3` -> `2.0.0`: `major`
- `1.2.3` -> `1.3.0`: `minor`
- `1.2.3` -> `1.2.4`: `patch`

## next version has a tag
- `1.2.3` -> `1.2.4-alpha.0`: `prerelease`
- `1.2.4-alpha.0` -> `1.2.4-alpha.1`: `prerelease`

## version with a tag -> version without one
- `1.2.4-alpha.0` -> `1.2.4`: `patch`
- `1.2.4-alpha.0` -> `1.2.5`: `patch`
- `1.2.4-alpha.0` -> `1.3.0`: `minor`
- `1.2.4-alpha.0` -> `2.0.0`: `major`
- `1.3.0-alpha.0` -> `1.3.0`: `minor`
Just like normal cases, the new version decides the `releaseType`.