### PR TITLE
fix: allow @(a|b|c) syntax for packagesToBump and packagesToPublish

### DIFF
--- a/packages/shipjs-lib/src/lib/util/__tests__/expandPackageList.spec.js
+++ b/packages/shipjs-lib/src/lib/util/__tests__/expandPackageList.spec.js
@@ -17,6 +17,31 @@ describe('expandPackageList', () => {
     ]);
   });
 
+  it('expands package list with @(x|y) expression', () => {
+    silentExec('./tests/bootstrap-examples/simple-monorepo.sh');
+
+    expect(
+      expandPackageList(
+        ['.', 'packages/@(package_a|package_b)'],
+        'sandbox/simple-monorepo'
+      )
+    ).toEqual([
+      `${process.cwd()}/sandbox/simple-monorepo`,
+      `${process.cwd()}/sandbox/simple-monorepo/packages/package_a`,
+      `${process.cwd()}/sandbox/simple-monorepo/packages/package_b`,
+    ]);
+
+    expect(
+      expandPackageList(
+        ['.', 'packages/@(package_a|not-existing)'],
+        'sandbox/simple-monorepo'
+      )
+    ).toEqual([
+      `${process.cwd()}/sandbox/simple-monorepo`,
+      `${process.cwd()}/sandbox/simple-monorepo/packages/package_a`,
+    ]);
+  });
+
   it('gets only directories with package.json', () => {
     silentExec('./tests/bootstrap-examples/monorepo-with-nonpkg-directory.sh');
     const projectName = 'monorepo-with-nonpkg-directory';

--- a/packages/shipjs-lib/src/lib/util/expandPackageList.js
+++ b/packages/shipjs-lib/src/lib/util/expandPackageList.js
@@ -1,4 +1,4 @@
-import { resolve, join } from 'path';
+import { resolve, join, sep } from 'path';
 import { statSync, readdirSync, existsSync } from 'fs';
 
 const isDirectory = dir => statSync(dir).isDirectory();
@@ -12,12 +12,29 @@ const flatten = arr => arr.reduce((acc, item) => acc.concat(item), []);
 export default function expandPackageList(list, dir = '.') {
   return flatten(
     list.map(item => {
+      const partIndex = item
+        .split(sep)
+        .findIndex(part => part.startsWith('@(') && part.endsWith(')'));
+      if (partIndex !== -1) {
+        const parts = item.split(sep);
+        const part = parts[partIndex];
+        const newList = part
+          .slice(2, part.length - 1)
+          .split('|')
+          .map(subPart => {
+            const newParts = [...parts];
+            newParts[partIndex] = subPart;
+            return newParts.join(sep);
+          });
+        return expandPackageList(newList, dir);
+      }
+
       if (item.endsWith('/*')) {
         const basePath = resolve(dir, item.slice(0, item.length - 2));
-        return getDirectories(basePath).filter(hasPackageJson);
+        return expandPackageList(getDirectories(basePath), dir);
       } else {
         return resolve(dir, item);
       }
     })
-  );
+  ).filter(hasPackageJson);
 }


### PR DESCRIPTION
fix #658 
fix #700 