### PR TITLE
chore(shipjs): do not include __tests__ directory

### DIFF
--- a/packages/shipjs/package.json
+++ b/packages/shipjs/package.json
@@ -23,6 +23,7 @@
   "files": [
     "bin/shipjs",
     "src",
+    "!src/**/__tests__",
     "index.js"
   ],
   "author": "Algolia <support@algolia.com>",


### PR DESCRIPTION
This is not good...
<img width="401" alt="スクリーンショット 2020-05-07 22 12 58" src="https://user-images.githubusercontent.com/28397593/81298604-f1e1b900-90af-11ea-8e24-67ef5d034e0a.png">

`files` key in package.json can select that not to include directory.
like this!!
https://github.com/stylelint/stylelint/blob/master/package.json#L33