### PR TITLE
feat: add basic support for esm

### DIFF
--- a/packages/shipjs-lib/babel.config.js
+++ b/packages/shipjs-lib/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  presets: ['@babel/preset-env'],
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
 };

--- a/packages/shipjs-lib/jest.config.js
+++ b/packages/shipjs-lib/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   transform: {
     '^.+\\.[t|j]sx?$': 'babel-jest',
   },
+  testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/src/lib/config/__tests__/example'],
   watchPathIgnorePatterns: ['<rootDir>/sandbox'],
   watchPlugins: [

--- a/packages/shipjs-lib/src/lib/config/__tests__/cjs/ship.config.cjs
+++ b/packages/shipjs-lib/src/lib/config/__tests__/cjs/ship.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  versionUpdated() {},
+};

--- a/packages/shipjs-lib/src/lib/config/__tests__/loadConfig.spec.js
+++ b/packages/shipjs-lib/src/lib/config/__tests__/loadConfig.spec.js
@@ -4,7 +4,7 @@ import path from 'path';
 
 const baseConfig = expect.objectContaining({});
 
-const d = dirName => path.resolve(__dirname, dirName);
+const d = (dirName) => path.resolve(__dirname, dirName);
 
 describe('loadConfig', () => {
   it('does not throw when there is no config', async () => {

--- a/packages/shipjs-lib/src/lib/config/__tests__/loadConfig.spec.js
+++ b/packages/shipjs-lib/src/lib/config/__tests__/loadConfig.spec.js
@@ -4,24 +4,29 @@ import path from 'path';
 
 const baseConfig = expect.objectContaining({});
 
-const d = (dirName) => path.resolve(__dirname, dirName);
+const d = dirName => path.resolve(__dirname, dirName);
 
 describe('loadConfig', () => {
-  it('does not throw when there is no config', () => {
-    expect(loadConfig(d('non-existing-dir'))).toMatchObject(baseConfig);
+  it('does not throw when there is no config', async () => {
+    expect(await loadConfig(d('non-existing-dir'))).toMatchObject(baseConfig);
   });
 
-  it('should load config', () => {
-    expect(loadConfig(d('example'))).toMatchObject(baseConfig);
+  it('should load config', async () => {
+    expect(await loadConfig(d('example'))).toMatchObject(baseConfig);
   });
 
-  it('should get function properly', () => {
-    const config = loadConfig(d('example'));
+  it('should load config with cjs ext', async () => {
+    const config = await loadConfig(d('cjs'));
     expect(typeof config.versionUpdated).toBe('function');
   });
 
-  it('should merge defaultConfig and userConfig', () => {
-    const config = loadConfig(d('example'));
+  it('should get function properly', async () => {
+    const config = await loadConfig(d('example'));
+    expect(typeof config.versionUpdated).toBe('function');
+  });
+
+  it('should merge defaultConfig and userConfig', async () => {
+    const config = await loadConfig(d('example'));
     expect(config.conventionalChangelogArgs).toBe(
       defaultConfig.conventionalChangelogArgs
     );

--- a/packages/shipjs-lib/src/lib/config/loadConfig.js
+++ b/packages/shipjs-lib/src/lib/config/loadConfig.js
@@ -1,13 +1,13 @@
 import dotenv from 'dotenv';
 import { resolve } from 'path';
-import { promises, constants } from 'fs';
+import { promises as fs, constants } from 'fs';
 
 import defaultConfig from './defaultConfig';
 import mergeConfig from './mergeConfig';
 dotenv.config();
 
 const exist = path =>
-  promises
+  fs
     .access(path, constants.F_OK)
     .then(() => path)
     .catch(() => false);

--- a/packages/shipjs-lib/src/lib/config/loadConfig.js
+++ b/packages/shipjs-lib/src/lib/config/loadConfig.js
@@ -1,13 +1,30 @@
 import dotenv from 'dotenv';
 import { resolve } from 'path';
-import { existsSync } from 'fs';
+import { promises, constants } from 'fs';
 
 import defaultConfig from './defaultConfig';
 import mergeConfig from './mergeConfig';
 dotenv.config();
 
-export default function loadConfig(dir = '.', filename = 'ship.config.js') {
-  const fullPath = resolve(dir, filename);
-  const userConfig = existsSync(fullPath) ? require(fullPath) : {};
+const exist = path =>
+  promises
+    .access(path, constants.F_OK)
+    .then(() => path)
+    .catch(() => false);
+
+export default async function loadConfig(
+  dir = '.',
+  filename = 'ship.config',
+  extensions = ['js', 'cjs', 'mjs']
+) {
+  const fullPaths = extensions.map(ext => resolve(dir, `${filename}.${ext}`));
+
+  const fullPath = (await Promise.all(fullPaths.map(path => exist(path)))).find(
+    path => path
+  );
+
+  const userConfig =
+    fullPath && (await exist(fullPath)) ? await import(fullPath) : {};
+
   return mergeConfig(defaultConfig, userConfig);
 }

--- a/packages/shipjs-lib/src/lib/config/loadConfig.js
+++ b/packages/shipjs-lib/src/lib/config/loadConfig.js
@@ -12,6 +12,9 @@ const exist = path =>
     .then(() => path)
     .catch(() => false);
 
+const pickDefault = obj =>
+  typeof obj.default === 'object' ? obj.default : obj;
+
 export default async function loadConfig(
   dir = '.',
   filename = 'ship.config',
@@ -24,7 +27,9 @@ export default async function loadConfig(
   );
 
   const userConfig =
-    fullPath && (await exist(fullPath)) ? await import(fullPath) : {};
+    fullPath && (await exist(fullPath))
+      ? await import(fullPath).then(pickDefault)
+      : {};
 
   return mergeConfig(defaultConfig, userConfig);
 }

--- a/packages/shipjs-lib/src/lib/config/loadConfig.js
+++ b/packages/shipjs-lib/src/lib/config/loadConfig.js
@@ -6,13 +6,13 @@ import defaultConfig from './defaultConfig';
 import mergeConfig from './mergeConfig';
 dotenv.config();
 
-const exist = path =>
+const exist = (path) =>
   fs
     .access(path, constants.F_OK)
     .then(() => path)
     .catch(() => false);
 
-const pickDefault = obj =>
+const pickDefault = (obj) =>
   typeof obj.default === 'object' ? obj.default : obj;
 
 export default async function loadConfig(
@@ -20,11 +20,11 @@ export default async function loadConfig(
   filename = 'ship.config',
   extensions = ['js', 'cjs', 'mjs']
 ) {
-  const fullPaths = extensions.map(ext => resolve(dir, `${filename}.${ext}`));
+  const fullPaths = extensions.map((ext) => resolve(dir, `${filename}.${ext}`));
 
-  const fullPath = (await Promise.all(fullPaths.map(path => exist(path)))).find(
-    path => path
-  );
+  const fullPath = (
+    await Promise.all(fullPaths.map((path) => exist(path)))
+  ).find((path) => path);
 
   const userConfig =
     fullPath && (await exist(fullPath))

--- a/packages/shipjs-lib/src/lib/util/getAppName.js
+++ b/packages/shipjs-lib/src/lib/util/getAppName.js
@@ -1,4 +1,4 @@
-import { promises } from 'fs';
+import { promises as fs } from 'fs';
 import { resolve } from 'path';
 import loadConfig from '../config/loadConfig';
 
@@ -8,7 +8,7 @@ export default async function getAppName(dir = '.') {
     return appName;
   }
   const { name } = JSON.parse(
-    await promises.readFile(resolve(dir, 'package.json'))
+    await fs.readFile(resolve(dir, 'package.json'))
   );
   return name;
 }

--- a/packages/shipjs-lib/src/lib/util/getAppName.js
+++ b/packages/shipjs-lib/src/lib/util/getAppName.js
@@ -1,12 +1,14 @@
-import { readFileSync } from 'fs';
+import { promises } from 'fs';
 import { resolve } from 'path';
 import loadConfig from '../config/loadConfig';
 
-export default function getAppName(dir = '.') {
-  const { appName } = loadConfig(dir);
+export default async function getAppName(dir = '.') {
+  const { appName } = await loadConfig(dir);
   if (appName) {
     return appName;
   }
-  const { name } = JSON.parse(readFileSync(resolve(dir, 'package.json')));
+  const { name } = JSON.parse(
+    await promises.readFile(resolve(dir, 'package.json'))
+  );
   return name;
 }

--- a/packages/shipjs-lib/src/lib/util/getAppName.js
+++ b/packages/shipjs-lib/src/lib/util/getAppName.js
@@ -7,8 +7,6 @@ export default async function getAppName(dir = '.') {
   if (appName) {
     return appName;
   }
-  const { name } = JSON.parse(
-    await fs.readFile(resolve(dir, 'package.json'))
-  );
+  const { name } = JSON.parse(await fs.readFile(resolve(dir, 'package.json')));
   return name;
 }

--- a/packages/shipjs/babel.config.js
+++ b/packages/shipjs/babel.config.js
@@ -9,12 +9,4 @@ module.exports = {
       },
     ],
   ],
-  plugins: [
-    [
-      '@babel/plugin-transform-runtime',
-      {
-        regenerator: true,
-      },
-    ],
-  ],
 };

--- a/packages/shipjs/jest.config.js
+++ b/packages/shipjs/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   transform: {
     '^.+\\.[t|j]sx?$': 'babel-jest',
   },
+  testEnvironment: 'node',
   watchPlugins: [
     'jest-watch-typeahead/filename',
     'jest-watch-typeahead/testname',

--- a/packages/shipjs/src/flow/prepare.js
+++ b/packages/shipjs/src/flow/prepare.js
@@ -45,7 +45,7 @@ async function prepare({
   }
   printDeprecated({ firstRelease, releaseCount });
   checkGitHubToken({ dryRun });
-  const config = loadConfig(dir);
+  const config = await loadConfig(dir);
   const { currentVersion, baseBranch } = validate({ config, dir });
   const { remote, forcePushBranches } = config;
   pull({ remote, currentBranch: baseBranch, dir, dryRun });
@@ -120,7 +120,7 @@ async function prepare({
     dir,
     dryRun,
   });
-  const appName = getAppName(dir);
+  const appName = await getAppName(dir);
   await notifyPrepared({
     config,
     appName,

--- a/packages/shipjs/src/flow/release.js
+++ b/packages/shipjs/src/flow/release.js
@@ -26,7 +26,7 @@ async function release({ help = false, dir = '.', dryRun = false }) {
     printDryRunBanner();
   }
   checkGitHubToken({ dryRun });
-  const config = loadConfig(dir);
+  const config = await loadConfig(dir);
   const { remote } = config;
   const { currentVersion: version } = validate({ config, dir });
   const {
@@ -35,7 +35,7 @@ async function release({ help = false, dir = '.', dryRun = false }) {
     latestCommitUrl,
     repoURL,
     releaseTag,
-  } = gatherRepoInfo({ remote, version, dir });
+  } = await gatherRepoInfo({ remote, version, dir });
   const isYarn = detectYarn(dir);
   runTest({ isYarn, config, dir, dryRun });
   runBuild({ isYarn, config, version, dir, dryRun });

--- a/packages/shipjs/src/step/prepare/__tests__/createPullRequest.spec.js
+++ b/packages/shipjs/src/step/prepare/__tests__/createPullRequest.spec.js
@@ -56,7 +56,7 @@ describe('createPullRequest', () => {
     const create = jest.fn().mockImplementationOnce(() => ({
       data: { number: 13, html_url: 'https://github.com/my/repo/pull/13' }, // eslint-disable-line camelcase
     }));
-    Octokit.mockImplementationOnce(function () {
+    Octokit.mockImplementationOnce(function() {
       this.pulls = { create, createReviewRequest: jest.fn() };
     });
     const { pullRequestUrl } = await createPullRequest(getDefaultParams());

--- a/packages/shipjs/src/step/prepare/__tests__/createPullRequest.spec.js
+++ b/packages/shipjs/src/step/prepare/__tests__/createPullRequest.spec.js
@@ -56,7 +56,7 @@ describe('createPullRequest', () => {
     const create = jest.fn().mockImplementationOnce(() => ({
       data: { number: 13, html_url: 'https://github.com/my/repo/pull/13' }, // eslint-disable-line camelcase
     }));
-    Octokit.mockImplementationOnce(function() {
+    Octokit.mockImplementationOnce(function () {
       this.pulls = { create, createReviewRequest: jest.fn() };
     });
     const { pullRequestUrl } = await createPullRequest(getDefaultParams());

--- a/packages/shipjs/src/step/release/gatherRepoInfo.js
+++ b/packages/shipjs/src/step/release/gatherRepoInfo.js
@@ -7,9 +7,9 @@ import {
 } from 'shipjs-lib';
 import runStep from '../runStep';
 
-export default ({ remote, version, dir }) =>
-  runStep({ title: 'Gathering repository information.' }, () => {
-    const appName = getAppName(dir);
+export default async ({ remote, version, dir }) =>
+  await runStep({ title: 'Gathering repository information.' }, async () => {
+    const appName = await getAppName(dir);
     const latestCommitHash = getLatestCommitHash(dir);
     const latestCommitUrl = getCommitUrl(remote, latestCommitHash, dir);
     const { url: repoURL } = getRepoInfo(remote, dir);


### PR DESCRIPTION
hey @eunjae-lee! 
how are you? 🙌🏻

I mirgate same of my project to esm modules with `"type": "module"`, so now i can't use shipjs, because it load only `shipjs.config.js`
I added `cjs`, `mjs`, `js` possible extensions to config and use first existed, so it should solve the problem

also improve config for tests ❤️