### PR TITLE
fix(setup): add --tag to publish command in generated config

### DIFF
--- a/packages/shipjs/src/step/setup/addShipConfig.js
+++ b/packages/shipjs/src/step/setup/addShipConfig.js
@@ -22,8 +22,8 @@ export default async ({
     const config = {
       ...(isScoped &&
         isPublic && {
-          publishCommand: ({ defaultCommand }) =>
-            `${defaultCommand} --access public`,
+          publishCommand: ({ defaultCommand, tag }) =>
+            `${defaultCommand} --access public --tag ${tag}`,
         }),
       ...(useMonorepo && {
         monorepo: {


### PR DESCRIPTION
This PR adds `--tag` to publishCommand in generated config by `shipjs setup`