### PR TITLE
fix(trigger): replace yarn publish with npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ When releasing, you go through something like the following:
 
 - Update the version in `package.json`
 - Update the changelog
-- Actually release it (e.g. `yarn build && yarn publish`)
+- Actually release it (e.g. `npm run build && npm publish`)
 - Create a git tag
 - Create a release on GitHub
 

--- a/packages/shipjs/src/helper/getPublishCommand.js
+++ b/packages/shipjs/src/helper/getPublishCommand.js
@@ -4,9 +4,9 @@ export default function getPublishCommand({
   tag,
   dir,
 }) {
-  const defaultCommand = isYarn
-    ? `yarn publish --no-git-tag-version --non-interactive --tag ${tag}`
-    : `npm publish --tag ${tag}`;
+  const npmPublish = `npm publish --tag ${tag}`;
+  const setRegistry = 'npm_config_registry=https://registry.npmjs.org/';
+  const defaultCommand = isYarn ? `${setRegistry} ${npmPublish}` : npmPublish;
 
   return publishCommand({ isYarn, tag, defaultCommand, dir });
 }

--- a/packages/shipjs/src/step/release/__tests__/runPublish.spec.js
+++ b/packages/shipjs/src/step/release/__tests__/runPublish.spec.js
@@ -22,7 +22,7 @@ describe('runPublish', () => {
     expect(run).toHaveBeenCalledTimes(1);
     expect(run.mock.calls[0][0]).toMatchInlineSnapshot(`
       Object {
-        "command": "yarn publish --no-git-tag-version --non-interactive --tag latest",
+        "command": "npm_config_registry=https://registry.npmjs.org/ npm publish --tag latest",
         "dir": ".",
         "dryRun": false,
       }
@@ -76,14 +76,14 @@ describe('runPublish', () => {
     expect(run).toHaveBeenCalledTimes(2);
     expect(run.mock.calls[0][0]).toMatchInlineSnapshot(`
       Object {
-        "command": "yarn publish --no-git-tag-version --non-interactive --tag latest",
+        "command": "npm_config_registry=https://registry.npmjs.org/ npm publish --tag latest",
         "dir": "/package-a",
         "dryRun": false,
       }
     `);
     expect(run.mock.calls[1][0]).toMatchInlineSnapshot(`
       Object {
-        "command": "yarn publish --no-git-tag-version --non-interactive --tag latest",
+        "command": "npm_config_registry=https://registry.npmjs.org/ npm publish --tag latest",
         "dir": "/package-b",
         "dryRun": false,
       }

--- a/website/guide/README.md
+++ b/website/guide/README.md
@@ -30,7 +30,7 @@ When releasing, you go through something like the following:
 
 - Update the version in `package.json`
 - Update the changelog
-- Actually release it (e.g. `yarn build && yarn publish`)
+- Actually release it (e.g. `npm run build && npm publish`)
 - Create a git tag
 - Create a release on GitHub
 

--- a/website/guide/useful-config.md
+++ b/website/guide/useful-config.md
@@ -169,6 +169,6 @@ module.exports = {
 };
 ```
 
-By default, `publishCommand` returns `yarn publish` or `npm publish`. You can override it like the above to release it to wherever you want.
+By default, `publishCommand` returns `npm publish`. You can override it like the above to release it to wherever you want.
 
 If you have configured `monorepo`, this command will run in each package in `monorepo.packagesToPublish`.

--- a/website/reference/all-config.md
+++ b/website/reference/all-config.md
@@ -227,11 +227,11 @@ publishCommand: ({ isYarn, tag, defaultCommand, dir }) => defaultCommand;
 
 ```js
 isYarn
-  ? `yarn publish --no-git-tag-version --non-interactive --tag ${tag}`
+  ? `npm_config_registry=https://registry.npmjs.org/ npm publish --tag ${tag}`
   : `npm publish --tag ${tag}`;
 ```
 
-By default, `publishCommand` will return either `yarn publish ...` or `npm publish ...`.
+By default, `publishCommand` will return `npm publish ...`.
 
 ### Scoped Package
 


### PR DESCRIPTION
This PR replaces `yarn publish` with `npm publish` even if user is using `yarn`.

`yarn publish` uses `yarn pack` under the hood, and there is [a critical bug](https://github.com/yarnpkg/yarn/issues/8332) in `yarn pack`.

Replacing `yarn publish` with `npm publish` requires an extra job, which is to set `registry` to the one of npm. Even though Ship.js calls `npm publish`, if it's triggered by `yarn shipjs trigger`, then yarn overrides the registry. It's coming from `~/.yarnrc`. To revert this back, we need to prepend `npm_config_registry=https://registry.npmjs.org/` to set the registry correctly.