### PR TITLE
fix: update registry before publish instead of using env var which didn't work

### DIFF
--- a/packages/shipjs/src/helper/getPublishCommand.js
+++ b/packages/shipjs/src/helper/getPublishCommand.js
@@ -4,9 +4,7 @@ export default function getPublishCommand({
   tag,
   dir,
 }) {
-  const npmPublish = `npm publish --tag ${tag}`;
-  const setRegistry = 'npm_config_registry=https://registry.npmjs.org/';
-  const defaultCommand = isYarn ? `${setRegistry} ${npmPublish}` : npmPublish;
+  const defaultCommand = `npm publish --tag ${tag}`;
 
   return publishCommand({ isYarn, tag, defaultCommand, dir });
 }

--- a/packages/shipjs/src/step/release/__tests__/runPublish.spec.js
+++ b/packages/shipjs/src/step/release/__tests__/runPublish.spec.js
@@ -19,10 +19,17 @@ describe('runPublish', () => {
       dir: '.',
       dryRun: false,
     });
-    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(2);
     expect(run.mock.calls[0][0]).toMatchInlineSnapshot(`
       Object {
-        "command": "npm_config_registry=https://registry.npmjs.org/ npm publish --tag latest",
+        "command": "yarn config set registry https://registry.npmjs.org/",
+        "dir": ".",
+        "dryRun": false,
+      }
+    `);
+    expect(run.mock.calls[1][0]).toMatchInlineSnapshot(`
+      Object {
+        "command": "npm publish --tag latest",
         "dir": ".",
         "dryRun": false,
       }
@@ -69,21 +76,29 @@ describe('runPublish', () => {
     expect(output).toMatchInlineSnapshot(`
       Array [
         "› Publishing.",
+        "Configuring the registry to https://registry.npmjs.org/",
         "Running the following at /package-a",
         "Running the following at /package-b",
       ]
     `);
-    expect(run).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenCalledTimes(3);
     expect(run.mock.calls[0][0]).toMatchInlineSnapshot(`
       Object {
-        "command": "npm_config_registry=https://registry.npmjs.org/ npm publish --tag latest",
-        "dir": "/package-a",
+        "command": "yarn config set registry https://registry.npmjs.org/",
+        "dir": ".",
         "dryRun": false,
       }
     `);
     expect(run.mock.calls[1][0]).toMatchInlineSnapshot(`
       Object {
-        "command": "npm_config_registry=https://registry.npmjs.org/ npm publish --tag latest",
+        "command": "npm publish --tag latest",
+        "dir": "/package-a",
+        "dryRun": false,
+      }
+    `);
+    expect(run.mock.calls[2][0]).toMatchInlineSnapshot(`
+      Object {
+        "command": "npm publish --tag latest",
         "dir": "/package-b",
         "dryRun": false,
       }

--- a/packages/shipjs/src/step/release/runPublish.js
+++ b/packages/shipjs/src/step/release/runPublish.js
@@ -8,6 +8,15 @@ export default ({ isYarn, config, releaseTag: tag, dir, dryRun }) =>
   runStep({ title: 'Publishing.' }, () => {
     const { publishCommand, monorepo } = config;
 
+    if (isYarn) {
+      print('Configuring the registry to https://registry.npmjs.org/');
+      run({
+        command: 'yarn config set registry https://registry.npmjs.org/',
+        dir,
+        dryRun,
+      });
+    }
+
     if (monorepo) {
       const { packagesToPublish } = monorepo;
       const packageList = expandPackageList(packagesToPublish, dir);


### PR DESCRIPTION
Prepending `npm_config_registry=https://registry.npmjs.org/` didn't work (https://github.com/algolia/shipjs/pull/919)
Now it just calls `yarn config set registry https://registry.npmjs.org/` to correct the registry.