### PR TITLE
fix: set npm config to read NPM_AUTH_TOKEN

### DIFF
--- a/packages/shipjs/src/step/release/__tests__/runPublish.spec.js
+++ b/packages/shipjs/src/step/release/__tests__/runPublish.spec.js
@@ -19,8 +19,15 @@ describe('runPublish', () => {
       dir: '.',
       dryRun: false,
     });
-    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(2);
     expect(run.mock.calls[0][0]).toMatchInlineSnapshot(`
+      Object {
+        "command": "npm config set \\"//registry.npmjs.org/:_authToken\\" \\"\\\\\${NPM_AUTH_TOKEN}\\"",
+        "dir": ".",
+        "dryRun": false,
+      }
+    `);
+    expect(run.mock.calls[1][0]).toMatchInlineSnapshot(`
       Object {
         "command": "npm_config_registry=https://registry.npmjs.org/ npm publish --tag latest",
         "dir": ".",
@@ -39,8 +46,15 @@ describe('runPublish', () => {
       dir: '.',
       dryRun: false,
     });
-    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(2);
     expect(run.mock.calls[0][0]).toMatchInlineSnapshot(`
+      Object {
+        "command": "npm config set \\"//registry.npmjs.org/:_authToken\\" \\"\\\\\${NPM_AUTH_TOKEN}\\"",
+        "dir": ".",
+        "dryRun": false,
+      }
+    `);
+    expect(run.mock.calls[1][0]).toMatchInlineSnapshot(`
       Object {
         "command": "npm publish --tag latest",
         "dir": ".",
@@ -73,15 +87,22 @@ describe('runPublish', () => {
         "Running the following at /package-b",
       ]
     `);
-    expect(run).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenCalledTimes(3);
     expect(run.mock.calls[0][0]).toMatchInlineSnapshot(`
+      Object {
+        "command": "npm config set \\"//registry.npmjs.org/:_authToken\\" \\"\\\\\${NPM_AUTH_TOKEN}\\"",
+        "dir": ".",
+        "dryRun": false,
+      }
+    `);
+    expect(run.mock.calls[1][0]).toMatchInlineSnapshot(`
       Object {
         "command": "npm_config_registry=https://registry.npmjs.org/ npm publish --tag latest",
         "dir": "/package-a",
         "dryRun": false,
       }
     `);
-    expect(run.mock.calls[1][0]).toMatchInlineSnapshot(`
+    expect(run.mock.calls[2][0]).toMatchInlineSnapshot(`
       Object {
         "command": "npm_config_registry=https://registry.npmjs.org/ npm publish --tag latest",
         "dir": "/package-b",

--- a/packages/shipjs/src/step/release/runPublish.js
+++ b/packages/shipjs/src/step/release/runPublish.js
@@ -8,6 +8,14 @@ export default ({ isYarn, config, releaseTag: tag, dir, dryRun }) =>
   runStep({ title: 'Publishing.' }, () => {
     const { publishCommand, monorepo } = config;
 
+    // This adds the following line to ~/.npmrc
+    // > registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
+    run({
+      command: `npm config set "//registry.npmjs.org/:_authToken" "\\\${NPM_AUTH_TOKEN}"`,
+      dir,
+      dryRun,
+    });
+
     if (monorepo) {
       const { packagesToPublish } = monorepo;
       const packageList = expandPackageList(packagesToPublish, dir);


### PR DESCRIPTION
After multiple tries, I've found that this line is needs to be inside `~/.npmrc` in order to read `NPM_AUTH_TOKEN` environment variable when `npm publish` is called.

> registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

I feel like `npm publish` never worked before, meaning all of the Ship.js users use yarn?