### PR TITLE
fix: typo in GitHubAction config

### DIFF
--- a/packages/shipjs/src/step/setup/CI/addGitHubActions.js
+++ b/packages/shipjs/src/step/setup/CI/addGitHubActions.js
@@ -106,7 +106,7 @@ jobs:
       - run: npx shipjs trigger
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: \${{ secrets.NPM_AUTH_TOKEN }}
+          NPM_AUTH_TOKEN: \${{ secrets.NPM_AUTH_TOKEN }}
           SLACK_INCOMING_HOOK: \${{ secrets.SLACK_INCOMING_HOOK }}
 `,
     { baseBranch }


### PR DESCRIPTION
`NODE_AUTH_TOKEN` is not used anywhere. And before fixing it, github action couldn't find `NPM_AUTH_TOKEN` from secrets so there was an issue publishing next npm package.