### PR TITLE
fix: use the `actions/github-script` action instead of the deprecated `actions/github` action

### DIFF
--- a/packages/shipjs/src/step/setup/CI/addGitHubActions.js
+++ b/packages/shipjs/src/step/setup/CI/addGitHubActions.js
@@ -151,22 +151,32 @@ jobs:
     needs: manual_prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github@master
-        env:
-          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/github-script@v3
         with:
-          args: comment "@\${{ github.actor }} \`shipjs prepare\` done"
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "@\${{github.actor}} \`shipjs prepare\` done"
+            })
 
   create_fail_comment:
     if: cancelled() || failure()
     needs: manual_prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github@master
-        env:
-          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/github-script@v3
         with:
-          args: comment "@\${{ github.actor }} \`shipjs prepare\` fail"
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "@\${{github.actor}} \`shipjs prepare\` fail"
+            })
 `,
     { baseBranch }
   );


### PR DESCRIPTION
The GitHub Actions jobs created by `shipjs setup` use the `actions/github` action. But the `actions/github` action is deprecated and it is recommended to use the `actions/github-script` action instead.

https://github.com/actions/github
> 🚨 This action is deprecated! Please use actions/github-script, instead.

So I've fixed the generated jobs to use `actions/github-script`.

https://github.com/miyajan/test-shipjs/pull/1
I have tested the fixed `create_done_comment` and `create_fail_comment` jobs on my test repository to make sure they work correctly.