### PR TITLE
Allow shouldPrepare callback to run during --dry-run

### DIFF
--- a/packages/shipjs/src/step/prepare/validatePreparationConditions.js
+++ b/packages/shipjs/src/step/prepare/validatePreparationConditions.js
@@ -13,7 +13,6 @@ export default async ({
   nextVersion,
   revisionRange,
   dir,
-  dryRun,
 }) =>
   await runStep(
     {
@@ -22,10 +21,6 @@ export default async ({
     },
     async () => {
       const { shouldPrepare } = config;
-      if (dryRun) {
-        print(`-> execute ${info('shouldPrepare()')} callback.`);
-        return;
-      }
       const releaseTag = getReleaseTag(nextVersion);
       const commits = getCommitTitles(revisionRange, dir);
       const { numbers: commitNumbersPerType } = getCommitNumbersPerType(


### PR DESCRIPTION
`shouldPrepare` should probably run during dry-run. 

However, I'm slightly worried about the existing implementations that might assume --dry-run continues to skip the function, especially if those functions make modifications to data/files beyond returning a boolean. Hopefully no one is doing this in practice?