### PR TITLE
fix(prepare): add missing version in the changelog

### DIFF
--- a/packages/shipjs/src/flow/prepare.js
+++ b/packages/shipjs/src/flow/prepare.js
@@ -95,6 +95,7 @@ async function prepare({
     config,
     revisionRange,
     firstRelease,
+    nextVersion,
     releaseCount,
     dir,
     dryRun,

--- a/packages/shipjs/src/step/prepare/updateChangelog.js
+++ b/packages/shipjs/src/step/prepare/updateChangelog.js
@@ -11,6 +11,7 @@ import { parseArgs } from '../../util';
 export default ({
   config,
   firstRelease,
+  nextVersion,
   releaseCount,
   revisionRange,
   dir,
@@ -37,7 +38,10 @@ export default ({
         }).then(({ args, gitRawCommitsOpts, templateContext }) => {
           runConventionalChangelog({
             args,
-            templateContext,
+            templateContext: {
+              ...templateContext,
+              version: nextVersion,
+            },
             gitRawCommitsOpts,
             resolve,
             reject,


### PR DESCRIPTION
## Summary

This PR adds missing version in the changelog in case the root `package.json` has no `version` field (which is quite common in monorepos.)

It adds `version` to the conventional-changelog context explicitly, so that it won't need to read it from `package.json`.