### PR TITLE
fix: add 'ci' to list of accepted types

### DIFF
--- a/packages/shipjs-lib/src/lib/const.js
+++ b/packages/shipjs-lib/src/lib/const.js
@@ -6,6 +6,7 @@ export const GIT_COMMIT_PREFIX_PATCH = new Set([
   'perf',
   'test',
   'chore',
+  'ci'
 ]);
 
 export const GIT_COMMIT_PREFIX_MINOR = new Set(['feat']);


### PR DESCRIPTION
Fixes issue of `ci` type commits being flagged as out of convention when they're in the spec.