### PR TITLE
docs: fix the argument passing in npm script

### DIFF
--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -61,7 +61,7 @@ If you're not sure, you can always run commands in dry mode.
 ```bash
 yarn run release --dry-run
 # or
-npm run release --dry-run
+npm run release -- --dry-run
 ```
 
 It will show you which steps are going to be executed without actually executing them.


### PR DESCRIPTION
The arguments of the npm script should be separated by `--`.

https://docs.npmjs.com/cli/v8/commands/npm-run-script#description
> Any positional arguments are passed to the specified script. Use -- to pass --prefixed flags and options which would otherwise be parsed by npm.