### PR TITLE
chore: remove renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "extends": ["config:base"],
-  "automerge": true,
-  "major": {
-    "automerge": false
-  }
-}


### PR DESCRIPTION
## Summary

This PR removes `renovate`. It's been creating a massive pull requests after every commit. We will revisit this.