### PR TITLE
fix: get remote branches correctly when there are multiple origins

### DIFF
--- a/packages/shipjs-lib/src/lib/git/__tests__/getRemoteBranches.spec.js
+++ b/packages/shipjs-lib/src/lib/git/__tests__/getRemoteBranches.spec.js
@@ -22,4 +22,28 @@ describe('getRemoteBranches', () => {
       'renovate/rollup-1.x',
     ]);
   });
+
+  it('works with multiple origins', () => {
+    silentExec
+      .mockImplementationOnce(() => 'origin\norigin2')
+      .mockImplementationOnce(
+        () => `  origin/HEAD -> origin/master
+      origin/chore/all-contributors
+      origin/master
+      origin/renovate/pin-dependencies
+      origin/renovate/rollup-1.x
+      origin2/fix/something
+      origin2/chore/test
+    `
+      );
+    const result = getRemoteBranches();
+    expect(result).toEqual([
+      'chore/all-contributors',
+      'master',
+      'renovate/pin-dependencies',
+      'renovate/rollup-1.x',
+      'fix/something',
+      'chore/test',
+    ]);
+  });
 });

--- a/packages/shipjs-lib/src/lib/git/getRemoteBranches.js
+++ b/packages/shipjs-lib/src/lib/git/getRemoteBranches.js
@@ -23,7 +23,7 @@ export default function getRemoteBranches(dir = '.') {
     .filter((line) => !line.includes(' -> '))
     .map((line) => {
       const origin = origins.find((_origin) => line.startsWith(`${_origin}/`));
-      return origin ? line.slice(origin.length + 1) : null;
+      return line.slice(origin.length + 1);
     })
     .filter(Boolean);
 }

--- a/packages/shipjs-lib/src/lib/git/getRemoteBranches.js
+++ b/packages/shipjs-lib/src/lib/git/getRemoteBranches.js
@@ -11,13 +11,19 @@ $ git branch -r
 */
 
 export default function getRemoteBranches(dir = '.') {
-  const remote = silentExec('git remote', { dir }).toString().trim();
+  const origins = silentExec('git remote', { dir })
+    .toString()
+    .trim()
+    .split('\n');
   return silentExec('git branch -r', { dir })
     .toString()
     .trim()
     .split('\n')
     .map((line) => line.trim())
-    .filter(Boolean)
     .filter((line) => !line.includes(' -> '))
-    .map((line) => line.slice(remote.length + 1));
+    .map((line) => {
+      const origin = origins.find((_origin) => line.startsWith(`${_origin}/`));
+      return origin ? line.slice(origin.length + 1) : null;
+    })
+    .filter(Boolean);
 }


### PR DESCRIPTION
## Summary

This PR fixes `getRemoteBranches` function to get remote branches correctly when there are multiple origins.

fixes #972