### PR TITLE
fix(github): use non-deprecated requestReviewers function

### DIFF
--- a/packages/shipjs/src/step/prepare/__tests__/createPullRequest.spec.js
+++ b/packages/shipjs/src/step/prepare/__tests__/createPullRequest.spec.js
@@ -57,7 +57,7 @@ describe('createPullRequest', () => {
       data: { number: 13, html_url: 'https://github.com/my/repo/pull/13' }, // eslint-disable-line camelcase
     }));
     Octokit.mockImplementationOnce(function () {
-      this.pulls = { create, createReviewRequest: jest.fn() };
+      this.pulls = { create, requestReviewers: jest.fn() };
     });
     const { pullRequestUrl } = await createPullRequest(getDefaultParams());
     expect(pullRequestUrl).toEqual('https://github.com/my/repo/pull/13');

--- a/packages/shipjs/src/step/prepare/createPullRequest.js
+++ b/packages/shipjs/src/step/prepare/createPullRequest.js
@@ -81,7 +81,7 @@ export default async ({
       (pullRequestReviewers || []).length > 0 ||
       (pullRequestTeamReviewers || []).length > 0
     ) {
-      await octokit.pulls.createReviewRequest({
+      await octokit.pulls.requestReviewers({
         owner,
         repo,
         pull_number: number, // eslint-disable-line camelcase


### PR DESCRIPTION
Instead of createReviewRequest, requestReviewers is used.

See: https://octokit.github.io/rest.js/v18/#pulls-request-reviewers and https://github.com/octokit/octokit.js/pull/1760