### PR TITLE
docs: update the author info in the website package

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,6 @@
     "vuepress": "1.5.0"
   },
   "main": "index.js",
-  "author": "Eunjae Lee <karis612@gmail.com> (https://github.com/eunjae-lee)",
+  "author": "Algolia",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

The author information in the `website` package was auto-generated. So I put Algolia instead, which seems more appropriate.