### PR TITLE
fix(release): rebase before pushing local branch and tag

### DIFF
--- a/packages/shipjs/src/flow/release.js
+++ b/packages/shipjs/src/flow/release.js
@@ -1,4 +1,4 @@
-import { loadConfig } from 'shipjs-lib';
+import { getCurrentBranch, loadConfig } from 'shipjs-lib';
 
 import printHelp from '../step/release/printHelp';
 import printDryRunBanner from '../step/printDryRunBanner';
@@ -15,6 +15,7 @@ import createGitHubRelease from '../step/release/createGitHubRelease';
 import notifyReleaseSuccess from '../step/release/notifyReleaseSuccess';
 import checkGitHubToken from '../step/checkGitHubToken';
 import finished from '../step/release/finished';
+import fetchAndRebase from '../step/fetchAndRebase';
 import { detectYarn } from '../util';
 
 async function release({ help = false, dir = '.', dryRun = false }) {
@@ -43,6 +44,8 @@ async function release({ help = false, dir = '.', dryRun = false }) {
   runPublish({ isYarn, config, releaseTag, dir, dryRun });
   await runAfterPublish({ version, releaseTag, config, dir, dryRun });
   const { tagName } = createGitTag({ version, config, dir, dryRun });
+  const currentBranch = getCurrentBranch(dir);
+  await fetchAndRebase({ remote, currentBranch, dir, dryRun });
   gitPush({ tagName, config, dir, dryRun });
   await createGitHubRelease({ version, config, dir, dryRun });
   await notifyReleaseSuccess({

--- a/packages/shipjs/src/step/fetchAndRebase.js
+++ b/packages/shipjs/src/step/fetchAndRebase.js
@@ -1,0 +1,11 @@
+import runStep from './runStep';
+import { run } from '../util';
+
+export default ({ remote, currentBranch, dir, dryRun }) =>
+  runStep({ title: 'Rebasing.' }, () => {
+    run({
+      command: `git fetch && git rebase ${remote}/${currentBranch} ${currentBranch}`,
+      dir,
+      dryRun,
+    });
+  });


### PR DESCRIPTION
**Summary**

On rare occasions, the release process orchestrated by Ship.js cannot be completed if the local main branch and its remote counterpart are not in sync, when an unrelated PR is merged just after a release is started for instance (see [one example](https://app.circleci.com/pipelines/github/algolia/react-instantsearch/3035/workflows/96a85590-ab4c-42d5-9433-009f3067a10f/jobs/56342?invite=true&invite=true#step-106-924) of such issue).

This is not critical, but it can be a bother as the latest git tag won't be pushed to the remote, and the releases list on GitHub will not be updated too.

This PR addresses the issue by performing a rebase onto the main branch in order to sync them before performing the git tag operation.

**Result**

The release flow should now be more resilient to this kind of issue.

> **Note**
> I could not find a way to integrate a test for this addition. Let me know if you have any guidance for that 🙏 .