### PR TITLE
ci: use environment variables from context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ workflows:
     jobs:
       - test
       - shipjs_trigger:
+          context: fx-libraries
           requires:
             - test
           filters:
@@ -100,6 +101,7 @@ workflows:
   gh_pages:
     jobs:
       - gh_pages:
+          context: fx-libraries
           filters:
             branches:
               only:
@@ -113,4 +115,5 @@ workflows:
               only:
                 - main
     jobs:
-      - prepare_release
+      - prepare_release:
+          context: fx-libraries


### PR DESCRIPTION
This PR updates the CircleCI config file so that jobs retrieve relevant environment variables from context. Doing this will allow us to use the same tokens in similar projects.