### PR TITLE
fix(tags): write an annotated git tag

### DIFF
--- a/packages/shipjs/src/step/release/__tests__/createGitTag.spec.js
+++ b/packages/shipjs/src/step/release/__tests__/createGitTag.spec.js
@@ -11,7 +11,7 @@ describe('createGitTag', () => {
     });
     expect(run).toHaveBeenCalledTimes(1);
     expect(run).toHaveBeenCalledWith({
-      command: 'git tag v1.2.3',
+      command: 'git tag -a v1.2.3 -m v1.2.3',
       dir: '.',
       dryRun: false,
     });
@@ -27,7 +27,8 @@ describe('createGitTag', () => {
     });
     expect(run).toHaveBeenCalledTimes(1);
     expect(run).toHaveBeenCalledWith({
-      command: 'git tag instantsearch.js@1.2.3 && git tag swag@4',
+      command:
+        'git tag -a instantsearch.js@1.2.3 -m instantsearch.js@1.2.3 && git tag -a swag@4 -m swag@4',
       dir: '.',
       dryRun: false,
     });

--- a/packages/shipjs/src/step/release/createGitTag.js
+++ b/packages/shipjs/src/step/release/createGitTag.js
@@ -5,7 +5,9 @@ export default ({ version, config, dir, dryRun }) =>
   runStep({ title: 'Creating a git tag.' }, () => {
     const { getTagName } = config;
     const tagNames = arrayify(getTagName({ version }));
-    const command = tagNames.map((tag) => `git tag ${tag}`).join(' && ');
+    const command = tagNames
+      .map((tag) => `git tag -a ${tag} -m ${tag}`)
+      .join(' && ');
     run({ command, dir, dryRun });
     return { tagNames };
   });


### PR DESCRIPTION
Some other tools like `git describe` (used by lerna) will only return annotated tags. As well, the git documentation ([link](https://git-scm.com/book/en/v2/Git-Basics-Tagging)) primarily documents writing annotated tags.

This commit changes the behaviour of tags written by shipjs to write annotated tags