### PR TITLE
feat(changelog): send tagname to changelog function

### DIFF
--- a/packages/shipjs/src/step/release/__tests__/createGitHubRelease.spec.js
+++ b/packages/shipjs/src/step/release/__tests__/createGitHubRelease.spec.js
@@ -209,6 +209,7 @@ describe('createGitHubRelease', () => {
       })
     );
     expect(mockExtractChangelog).toHaveBeenCalledWith({
+      tagName: 'v1.2.3',
       version: '1.2.3',
       dir: '.',
     });

--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -24,7 +24,7 @@ export default async ({ version, config, dir, dryRun }) =>
       for await (const tagName of tagNames) {
         // extract matching changelog
         const getChangelogFn = extractChangelog || getChangelog;
-        const changelog = getChangelogFn({ version, dir });
+        const changelog = getChangelogFn({ tagName, version, dir });
         const content = changelog || '';
 
         // handle assets


### PR DESCRIPTION
This PR allows an `extractChangelog` method set in user config to access the `tagName` property, facilitating the retrieval of an appropriate changelog in a monorepo context where publishing is left to lerna.