### PR TITLE
fix(github-actions): update versions of checkout and node actions

### DIFF
--- a/packages/shipjs/src/step/setup/CI/addGitHubActions.js
+++ b/packages/shipjs/src/step/setup/CI/addGitHubActions.js
@@ -90,11 +90,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'releases/v')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: <%= baseBranch %>
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           registry-url: "https://registry.npmjs.org"
       - run: |
@@ -127,11 +127,11 @@ jobs:
       startsWith(github.event.comment.body, '@shipjs prepare')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: <%= baseBranch %>
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
       - run: |
           if [ -f "yarn.lock" ]; then
             yarn install
@@ -193,11 +193,11 @@ jobs:
   schedule_prepare:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: <%= baseBranch %>
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
       - run: |
           if [ -f "yarn.lock" ]; then
             yarn install


### PR DESCRIPTION
When setting up shipjs, the user is prompted with choosing if they want to create a Github Action workflow. The template used references actions that default to Node.js 12, which is EOL and has more chance to be incompatible with some of the user's projects dependencies.

This PR updates those action to their latest version, which now default to Node.js 16.