### PR TITLE
fix(github): ensure release assets are ready before releasing

### DIFF
--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -63,7 +63,7 @@ export default async ({ version, config, dir, dryRun }) =>
         if (assetPaths.length > 0) {
           for (const assetPath of assetPaths) {
             const file = path.resolve(dir, assetPath);
-            octokit.repos.uploadReleaseAsset({
+            await octokit.repos.uploadReleaseAsset({
               file: fs.readFileSync(file),
               headers: {
                 'content-length': fs.statSync(file).size,


### PR DESCRIPTION
This PR enforces the asynchronous nature of the [Github Release Asset](https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset) method.

**Within a CI environment**
- We ensure that assets are uploaded one after the other (as part of the release) prior to the next step in the CI (or CI termination)