### PR TITLE
fix(github): update parameters used during upload of release assets

### DIFF
--- a/packages/shipjs/package.json
+++ b/packages/shipjs/package.json
@@ -48,7 +48,6 @@
     "esm": "3.2.25",
     "globby": "^10.0.1",
     "inquirer": "7.1.0",
-    "mime-types": "^2.1.25",
     "mkdirp": "^1.0.0",
     "open": "^7.0.0",
     "prettier": "^2.0.0",

--- a/packages/shipjs/src/step/release/__tests__/createGitHubRelease.spec.js
+++ b/packages/shipjs/src/step/release/__tests__/createGitHubRelease.spec.js
@@ -1,6 +1,5 @@
 import globby from 'globby';
 import fs from 'fs';
-import mime from 'mime-types';
 import { getRepoInfo } from 'shipjs-lib';
 import { Octokit } from '@octokit/rest';
 import createGitHubRelease from '../createGitHubRelease';
@@ -32,7 +31,7 @@ describe('createGitHubRelease', () => {
   beforeEach(() => {
     createRelease.mockImplementation(() => ({
       data: {
-        upload_url: 'https://dummy/upload/url', // eslint-disable-line camelcase
+        id: 'releaseId',
       },
     }));
 
@@ -46,7 +45,6 @@ describe('createGitHubRelease', () => {
     }));
     fs.readFileSync = jest.fn();
     fs.statSync = jest.fn().mockImplementation(() => ({ size: 1024 }));
-    mime.lookup.mockImplementation(() => 'application/zip');
     globby.mockImplementation((path) => Promise.resolve([path]));
   });
 
@@ -92,24 +90,20 @@ describe('createGitHubRelease', () => {
       Array [
         Array [
           Object {
-            "file": undefined,
-            "headers": Object {
-              "content-length": 1024,
-              "content-type": "application/zip",
-            },
+            "data": undefined,
             "name": "path1",
-            "url": "https://dummy/upload/url",
+            "owner": "my",
+            "release_id": "releaseId",
+            "repo": "repo",
           },
         ],
         Array [
           Object {
-            "file": undefined,
-            "headers": Object {
-              "content-length": 1024,
-              "content-type": "application/zip",
-            },
+            "data": undefined,
             "name": "path2",
-            "url": "https://dummy/upload/url",
+            "owner": "my",
+            "release_id": "releaseId",
+            "repo": "repo",
           },
         ],
       ]
@@ -139,24 +133,20 @@ describe('createGitHubRelease', () => {
       Array [
         Array [
           Object {
-            "file": undefined,
-            "headers": Object {
-              "content-length": 1024,
-              "content-type": "application/zip",
-            },
+            "data": undefined,
             "name": "path1",
-            "url": "https://dummy/upload/url",
+            "owner": "my",
+            "release_id": "releaseId",
+            "repo": "repo",
           },
         ],
         Array [
           Object {
-            "file": undefined,
-            "headers": Object {
-              "content-length": 1024,
-              "content-type": "application/zip",
-            },
+            "data": undefined,
             "name": "path2",
-            "url": "https://dummy/upload/url",
+            "owner": "my",
+            "release_id": "releaseId",
+            "repo": "repo",
           },
         ],
       ]
@@ -186,13 +176,11 @@ describe('createGitHubRelease', () => {
       Array [
         Array [
           Object {
-            "file": undefined,
-            "headers": Object {
-              "content-length": 1024,
-              "content-type": "application/zip",
-            },
+            "data": undefined,
             "name": "path1",
-            "url": "https://dummy/upload/url",
+            "owner": "my",
+            "release_id": "releaseId",
+            "repo": "repo",
           },
         ],
       ]

--- a/packages/shipjs/src/step/release/__tests__/createGitHubRelease.spec.js
+++ b/packages/shipjs/src/step/release/__tests__/createGitHubRelease.spec.js
@@ -8,7 +8,6 @@ jest.mock('@octokit/rest');
 jest.mock('globby');
 jest.mock('shipjs-lib');
 jest.mock('fs');
-jest.mock('mime-types');
 
 const getDefaultParams = ({
   assetsToUpload,

--- a/packages/shipjs/src/step/release/createGitHubRelease.js
+++ b/packages/shipjs/src/step/release/createGitHubRelease.js
@@ -62,15 +62,13 @@ export default async ({ version, config, dir, dryRun }) =>
         if (assetPaths.length > 0) {
           for (const assetPath of assetPaths) {
             const file = path.resolve(dir, assetPath);
-            const filename = assetPath.split('/').pop();
             await octokit.repos.uploadReleaseAsset({
               data: fs.readFileSync(file),
               owner,
               repo,
               release_id: releaseId, // eslint-disable-line camelcase
-              name: filename,
+              name: path.basename(assetPath),
             });
-            print(`asset uploaded: ${filename}`);
           }
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9876,7 +9876,7 @@ mime-db@1.42.0, "mime-db@>= 1.40.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.42.0.tgz#3e252907b4c7adb906597b4b65636272cf9e7bac"
   integrity sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==
 
-mime-types@^2.1.12, mime-types@^2.1.25, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.25"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.25.tgz#39772d46621f93e2a80a856c53b86a62156a6437"
   integrity sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==


### PR DESCRIPTION
The Octokit package powering ShipJS' integration with Github changed the parameters required for uploading a release asset. This change occurred between Octokit's [v16](https://octokit.github.io/rest.js/v16#repos-upload-release-asset) and [v17](https://octokit.github.io/rest.js/v17#repos-upload-release-asset).

ShipJS currently runs on top of v17 of the Octokit package. This means that the method in charge of uploading release assets is broken.

This PR updates this method so its compatible with v17 of the Octokit package.

The PR also includes tests associated with the upload of release assets.
