### PR TITLE
update reference of support@aloglia.com to new ticket link

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "engines": {
     "node": ">=8.16.0"
   },
-  "author": "Algolia <support@algolia.com>",
+  "author": "Algolia <https://alg.li/support>",
   "license": "MIT",
   "private": true,
   "workspaces": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
   "engines": {
     "node": ">=8.16.0"
   },
-  "author": "Algolia <https://alg.li/support>",
+  "author": {
+    "name": "Algolia",
+    "url": "https://www.algolia.com"
+  },
   "license": "MIT",
   "private": true,
   "workspaces": {


### PR DESCRIPTION
Hey team!
The Support team is currently in a process of removing support@algolia.com email from all GitHub repos and updating it to link to the new ticket form https://alg.li/support. We kindly ask that you review the changes made removing references to support@algolia.com
Thanks!