### PR TITLE
Support "!" skip patterns for package lists

### DIFF
--- a/packages/shipjs-lib/src/lib/util/__tests__/expandPackageList.spec.js
+++ b/packages/shipjs-lib/src/lib/util/__tests__/expandPackageList.spec.js
@@ -53,4 +53,25 @@ describe('expandPackageList', () => {
       `${process.cwd()}/sandbox/${projectName}/packages/package_b`,
     ]);
   });
+
+  it('ignores packages with "!" prefix in package directory', () => {
+    silentExec('./tests/bootstrap-examples/simple-monorepo.sh');
+
+    expect(
+      expandPackageList(
+        ['.', 'packages/*', '!packages/package_a'],
+        'sandbox/simple-monorepo'
+      )
+    ).toEqual([
+      `${process.cwd()}/sandbox/simple-monorepo`,
+      `${process.cwd()}/sandbox/simple-monorepo/packages/package_b`,
+    ]);
+
+    expect(
+      expandPackageList(
+        ['.', 'packages/*', '!packages/package_a', '!packages/package_b'],
+        'sandbox/simple-monorepo'
+      )
+    ).toEqual([`${process.cwd()}/sandbox/simple-monorepo`]);
+  });
 });

--- a/packages/shipjs-lib/src/lib/util/expandPackageList.js
+++ b/packages/shipjs-lib/src/lib/util/expandPackageList.js
@@ -10,8 +10,14 @@ const hasPackageJson = (dir) => existsSync(`${dir}/package.json`);
 const flatten = (arr) => arr.reduce((acc, item) => acc.concat(item), []);
 
 export default function expandPackageList(list, dir = '.') {
-  return flatten(
-    list.map((item) => {
+  const exclusions = list
+    .filter((item) => item.startsWith('!'))
+    .map((item) => resolve(dir, item.slice(1)));
+
+  const inclusions = list.filter((item) => !item.startsWith('!'));
+
+  const expandedInclusions = flatten(
+    inclusions.map((item) => {
       const partIndex = item
         .split(sep)
         .findIndex((part) => part.startsWith('@(') && part.endsWith(')'));
@@ -37,4 +43,6 @@ export default function expandPackageList(list, dir = '.') {
       }
     })
   ).filter(hasPackageJson);
+
+  return expandedInclusions.filter((pkg) => !exclusions.includes(pkg));
 }

--- a/website/guide/useful-config.md
+++ b/website/guide/useful-config.md
@@ -12,11 +12,19 @@ Ship.js currently supports monorepo project(Independent versioning is not suppor
 module.exports = {
   monorepo: {
     mainVersionFile: 'package.json', // or `lerna.json`, or whatever a json file you can read the latest `version` from.
-    packagesToBump: ['packages/*', 'examples/*'],
-    packagesToPublish: ['packages/*'],
+    packagesToBump: ['packages/*', 'examples/*', '!example/a'],
+    packagesToPublish: ['packages/*', '!examples/a'],
   },
 };
 ```
+
+Patterns supported in `packagesToBump` / `packagesToPublish`:
+- Plain paths (e.g. `.` or `packages/package_a`)
+- Trailing `/*` to include immediate subdirectories (e.g. `packages/*`)
+- `@(a|b)` style alternation (e.g. `packages/@(package_a|package_b)`)
+- Start with `!` to skip a path: `!packages/package_a`
+
+Ship.js only lists folders that have a `package.json`. Any paths that start with `!` are removed after the patterns are handled.
 
 With the config above, `prepare` command will
 


### PR DESCRIPTION
Adds support for "!" skip patterns in monorepo package lists, allowing individual packages to be excluded from version bumps or publishing while remaining in the repository.

This helps teams keep deprecated packages without updating their versions or releasing them, enabling gradual deprecation and preserving backward compatibility. Inspired by https://pnpm.io/pnpm-workspace_yaml.