### PR TITLE
fix(changelog): handle frozen commit objects from conventional-changelog-writer

### DIFF
--- a/packages/shipjs/src/step/prepare/updateChangelog.js
+++ b/packages/shipjs/src/step/prepare/updateChangelog.js
@@ -152,6 +152,21 @@ export async function prepareParams({
   return { args, gitRawCommitsOpts, templateContext };
 }
 
+// Wraps a transform function to clone commits before modification.
+// This is needed because conventional-changelog-writer freezes commit objects,
+// but presets like angular expect to mutate them.
+function wrapTransform(originalTransform) {
+  if (!originalTransform) {
+    return undefined;
+  }
+
+  return (commit, context) => {
+    const mutableCommit = JSON.parse(JSON.stringify(commit));
+
+    return originalTransform(mutableCommit, context);
+  };
+}
+
 function runConventionalChangelog({
   args,
   templateContext,
@@ -165,12 +180,15 @@ function runConventionalChangelog({
   }
 
   const { parserOpts, writerOpts } = args.config || {};
+  const wrappedWriterOpts = writerOpts
+    ? { ...writerOpts, transform: wrapTransform(writerOpts.transform) }
+    : undefined;
   const changelogStream = conventionalChangelogCore(
     args,
     templateContext,
     { ...gitRawCommitsOpts, path: dir },
     parserOpts ? { ...parserOpts } : undefined,
-    writerOpts ? { ...writerOpts } : undefined,
+    wrappedWriterOpts,
     { path: dir, cwd: dir }
   ).on('error', reject);
 

--- a/packages/shipjs/src/step/prepare/updateChangelog.js
+++ b/packages/shipjs/src/step/prepare/updateChangelog.js
@@ -169,8 +169,8 @@ function runConventionalChangelog({
     args,
     templateContext,
     { ...gitRawCommitsOpts, path: dir },
-    parserOpts,
-    writerOpts,
+    parserOpts ? { ...parserOpts } : undefined,
+    writerOpts ? { ...writerOpts } : undefined,
     { path: dir, cwd: dir }
   ).on('error', reject);
 


### PR DESCRIPTION
## Summary

- Fix "Cannot modify immutable object" error during changelog generation

## Problem

The `conventional-changelog-writer` library freezes commit objects, but presets like `angular` expect to mutate them in their `transform` function (e.g., `commit.type = 'Bug Fixes'`). This causes the error:

```
Error: Cannot modify immutable object.
    at Object.set (conventional-changelog-writer/dist/commit.js:15:19)
    at transform (conventional-changelog-angular/writerOpts.js:40:21)
```

## Solution

Add a `wrapTransform` helper that deep clones commits before passing them to the original transform function, allowing mutation while preserving the original frozen objects.