### PR TITLE
fix: prevent false-positive major bumps from breaking change detection

### DIFF
--- a/packages/shipjs-lib/src/lib/const.js
+++ b/packages/shipjs-lib/src/lib/const.js
@@ -11,6 +11,6 @@ export const GIT_COMMIT_PREFIX_PATCH = new Set([
 
 export const GIT_COMMIT_PREFIX_MINOR = new Set(['feat']);
 
-export const GIT_COMMIT_BREAKING_CHANGE = 'BREAKING CHANGE';
+export const GIT_COMMIT_BREAKING_CHANGE = /^BREAKING[ -]CHANGE\s*:/;
 
 export const RELEASE_BRANCH = 'releases';

--- a/packages/shipjs-lib/src/lib/util/__tests__/getNextVersion.spec.js
+++ b/packages/shipjs-lib/src/lib/util/__tests__/getNextVersion.spec.js
@@ -97,6 +97,55 @@ describe('getNextVersionFromCommitMessages', () => {
     expect(actual).toBe('1.0.0');
   });
 
+  it('detects major from BREAKING-CHANGE with hyphen', () => {
+    const version = '1.2.3';
+    const titles = 'feat: abc';
+    const bodies = 'BREAKING-CHANGE: this also breaks things.';
+    const { version: actual } = getNextVersionFromCommitMessages(
+      version,
+      titles,
+      bodies
+    );
+    expect(actual).toBe('2.0.0');
+  });
+
+  it('does not trigger major from prose mentioning breaking changes', () => {
+    const version = '1.2.3';
+    const titles = 'feat: upgrade storybook';
+    const bodies =
+      'This PR includes breaking changes around package consolidation.';
+    const { version: actual } = getNextVersionFromCommitMessages(
+      version,
+      titles,
+      bodies
+    );
+    expect(actual).toBe('1.3.0');
+  });
+
+  it('detects major from ! suffix in title', () => {
+    const version = '1.2.3';
+    const titles = 'feat!: remove deprecated API';
+    const bodies = '';
+    const { version: actual } = getNextVersionFromCommitMessages(
+      version,
+      titles,
+      bodies
+    );
+    expect(actual).toBe('2.0.0');
+  });
+
+  it('detects major from scoped ! suffix in title', () => {
+    const version = '1.2.3';
+    const titles = 'fix(auth)!: change token format';
+    const bodies = '';
+    const { version: actual } = getNextVersionFromCommitMessages(
+      version,
+      titles,
+      bodies
+    );
+    expect(actual).toBe('2.0.0');
+  });
+
   it('gets a null with no commit messages', () => {
     const version = '0.0.1';
     const titles = '';

--- a/packages/shipjs-lib/src/lib/util/getCommitNumbersPerType.js
+++ b/packages/shipjs-lib/src/lib/util/getCommitNumbersPerType.js
@@ -16,7 +16,7 @@ export default function getCommitNumbersPerType(commitTitles) {
       ignoredMessages.push(title);
       return;
     }
-    const prefix = match[1].toLowerCase();
+    const prefix = match[1].replace(/!$/, '').toLowerCase();
     if (
       GIT_COMMIT_PREFIX_PATCH.has(prefix) ||
       GIT_COMMIT_PREFIX_MINOR.has(prefix)

--- a/packages/shipjs-lib/src/lib/util/getNextVersion.js
+++ b/packages/shipjs-lib/src/lib/util/getNextVersion.js
@@ -18,8 +18,11 @@ export function getNextVersionFromCommitMessages(version, titles, bodies) {
     bodies
       .toUpperCase()
       .split('\n')
-      .some((line) => line.startsWith(GIT_COMMIT_BREAKING_CHANGE))
+      .some((line) => GIT_COMMIT_BREAKING_CHANGE.test(line.trim()))
   ) {
+    return { version: inc(version, 'major') };
+  }
+  if (titles.split('\n').some((line) => /^\w+(\(.*?\))?!:/.test(line.trim()))) {
     return { version: inc(version, 'major') };
   }
   const { numbers, ignoredMessages } = getCommitNumbersPerType(titles);


### PR DESCRIPTION
## Summary

- Fix false-positive major version bumps when commit bodies contain the words "breaking changes" in prose (e.g. "This PR includes breaking changes around package consolidation")
- Require the `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer colon separator per the Conventional Commits spec
- Add support for the `!` suffix in commit titles (e.g. `feat!:`, `fix(scope)!:`) to trigger major bumps
- Strip trailing `!` from prefixes in `getCommitNumbersPerType` so `feat!:` is correctly classified as `feat`

## Test plan

- [x] Added test: prose mentioning "breaking changes" does **not** trigger major
- [x] Added test: `BREAKING-CHANGE:` (hyphen variant) triggers major
- [x] Added test: `feat!:` triggers major
- [x] Added test: `fix(scope)!:` triggers major
- [x] All existing tests still pass